### PR TITLE
Improve student profile data handling

### DIFF
--- a/models/userModel.js
+++ b/models/userModel.js
@@ -65,7 +65,7 @@ async function generateStudentId() {
 
 async function createStudent({ username, name, email, password, studentId,
   firstName, lastName, suffix, address, city, state, zip, course, affiliateProgram,
-  phones, ssn, emergencyContact, admissionDate, startDate, endDate, classTime, classDays, totalHours,
+  phones, ssn, emergencyContact, admissionDate, startDate, endDate, classTime, classDays,
   tuition, grievanceAck, financialAid, referralName, referralEmail }) {
   const { salt, hash } = hashPassword(password);
   const docNow = new Date().toISOString();
@@ -84,7 +84,7 @@ async function createStudent({ username, name, email, password, studentId,
     phones: phones || {},
     ssn,
     emergencyContact: emergencyContact || {},
-    program: { admissionDate, startDate, endDate, classTime, classDays, totalHours },
+    program: { admissionDate, startDate, endDate, classTime, classDays },
     course,
     affiliateProgram,
     tuition: tuition || {},

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -390,11 +390,29 @@ router.post('/students/:id/sign-doc', async (req, res) => {
 
 router.post('/students/:id/step2', async (req, res) => {
   const id = Number(req.params.id);
-  const { tuitionTotal, startDate, endDate, classTime, classDays } = req.body;
+  const {
+    startDate,
+    endDate,
+    classTime,
+    classDays,
+    tuitionTuition,
+    tuitionRegistrationFee,
+    tuitionBooks,
+    tuitionEquipment,
+    tuitionMiscFees,
+    tuitionTotal
+  } = req.body;
   try {
     await userModel.updateProfile(id, {
       program: { startDate, endDate, classTime, classDays },
-      tuition: { totalCost: tuitionTotal }
+      tuition: {
+        tuition: tuitionTuition,
+        registrationFee: tuitionRegistrationFee,
+        books: tuitionBooks,
+        equipment: tuitionEquipment,
+        miscFees: tuitionMiscFees,
+        totalCost: tuitionTotal
+      }
     });
     const student = await userModel.findById(id);
     if (student && student.email) {

--- a/routes/student.js
+++ b/routes/student.js
@@ -54,7 +54,8 @@ router.post('/profile/complete', (req, res) => {
     const student = await userModel.findById(req.session.user.id);
     if (!student) return res.status(404).send('Not found');
     if (err) return res.status(400).render('student_profile', { student, role: 'student', step2Error: err.message,  signatureDocsConfig   });
-    const { emergencyName, emergencyRelation, emergencyPhone, agree, grievanceAck } = req.body;
+    const { ssn: rawSSN, emergencyName, emergencyRelation, emergencyPhone, agree, grievanceAck } = req.body;
+    const ssn = rawSSN ? String(rawSSN).replace(/\D/g, '') : undefined;
     if (!agree) {
       return res.status(400).render('student_profile', { student, role: 'student', step2Error: 'You must agree to the registration agreement.',signatureDocsConfig });
     }
@@ -63,6 +64,7 @@ router.post('/profile/complete', (req, res) => {
       const reg = docs.find(d => d.type === 'registration-agreement');
       if (reg) reg.agreed = true;
       await userModel.updateProfile(student.id, {
+        ssn,
         emergencyContact: { name: emergencyName, relation: emergencyRelation, phone: emergencyPhone },
         grievanceAcknowledged: !!grievanceAck,
         documents: docs

--- a/views/student_profile.ejs
+++ b/views/student_profile.ejs
@@ -110,6 +110,12 @@
   </div>
 
   <div class="container pb-4">
+    <div class="alert alert-info text-center">Make sure to click Add Signature after each signing, otherwise information may be lost.</div>
+    <% if (role === 'admin' && student.status !== 'approved') { %>
+      <form method="post" action="/admin/approve/<%= student.id %>" class="mb-3 text-end">
+        <button class="btn btn-success">Approve Student</button>
+      </form>
+    <% } %>
     <% if (typeof reset !== 'undefined' && reset) { %>
       <div class="alert alert-success text-center">Password reset email sent.</div>
     <% } %>
@@ -149,7 +155,7 @@
         </div>
         <div class="mb-2"><strong>Phones:</strong> Home: <%= student.profile?.phones?.home || '-' %>, Cell: <%= student.profile?.phones?.cell || '-' %>, Work: <%= student.profile?.phones?.work || '-' %></div>
         <!-- MASKED SSN -->
-        <div class="mb-2"><strong>SSN:</strong> <%= maskSSN(student.profile?.ssn) %></div>
+        <div class="mb-2"><strong>SSN:</strong> <%= role === 'admin' ? (student.profile?.ssn || '-') : maskSSN(student.profile?.ssn) %></div>
         <div class="mb-0"><strong>Emergency Contact:</strong> <%= student.profile?.emergencyContact?.name || '-' %> (<%= student.profile?.emergencyContact?.relation || '-' %>) - <%= student.profile?.emergencyContact?.phone || '-' %></div>
       </section>
 
@@ -162,7 +168,6 @@
         <div class="mb-2"><strong>End Date:</strong> <%= student.profile?.program?.endDate || '-' %></div>
         <div class="mb-2"><strong>Class Time:</strong> <%= student.profile?.program?.classTime || '-' %></div>
         <div class="mb-2"><strong>Days:</strong> <%= student.profile?.program?.classDays || '-' %></div>
-        <div class="mb-2"><strong>Total Hours:</strong> <%= student.profile?.program?.totalHours || '-' %></div>
         <div class="mb-0"><strong>Grievance Acknowledged:</strong> <%= student.profile?.grievanceAcknowledged ? 'Yes' : 'No' %></div>
       </section>
     </div>
@@ -199,12 +204,6 @@
           <input name="classDays" class="form-control" value="<%= student.profile?.program?.classDays || '' %>">
         </div>
 
-        <!-- NEW: Total Hours -->
-        <div class="col-md-6">
-          <label class="form-label">Total Hours</label>
-          <input type="number" step="1" min="0" name="totalHours" class="form-control" value="<%= student.profile?.program?.totalHours || '' %>">
-        </div>
-
         <hr class="mt-2">
 
         <div class="col-12">
@@ -237,7 +236,7 @@
         </div>
 
         <div class="col-12">
-          <button class="btn btn-primary">Save &amp; Send Step 2</button>
+          <button class="btn btn-primary">Send to Student</button>
         </div>
       </form>
     </section>


### PR DESCRIPTION
## Summary
- Persist student SSN so admins can review it and show unmasked for admins
- Save detailed tuition breakdown entered by admins
- Remove program total hours and add admin approval UX improvements

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab04584f68832bae5e2e44c5d730a8