### PR TITLE
feat: add teacher links

### DIFF
--- a/models/userModel.js
+++ b/models/userModel.js
@@ -259,6 +259,16 @@ async function addUploads(id, uploads) {
   return user;
 }
 
+async function addLinks(id, links) {
+  const user = await findById(id);
+  if (!user) return null;
+  user.profile = user.profile || {};
+  user.profile.links = user.profile.links || [];
+  user.profile.links.push(...links);
+  await db.query('UPDATE mdtslms_users SET profile=? WHERE id=?', [JSON.stringify(user.profile), id]);
+  return user;
+}
+
 async function setStatus(id, status) {
   const finishedAt = (status === 'approved' || status === 'declined') ? new Date().toISOString() : null;
   await db.query('UPDATE mdtslms_users SET status=?, finishedAt=? WHERE id=?', [status, finishedAt, id]);
@@ -294,6 +304,7 @@ module.exports = {
   setStatus,
     setActive,
   addUploads,
+  addLinks,
     signDocument,
         markApplicationComplete,
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -940,6 +940,22 @@ router.post('/teachers/:id/edit', mediaUpload.single('photo'), async (req, res) 
   res.redirect(`/admin/teachers/${id}/edit?saved=1`);
 });
 
+router.post('/teachers/:id/link', mediaUpload.single('image'), async (req, res) => {
+  const id = Number(req.params.id);
+  const teacher = await userModel.findById(id);
+  if (!teacher || teacher.role !== 'teacher') return res.status(404).send('Not found');
+  const { url } = req.body;
+  if (url) {
+    const link = { url };
+    if (req.file) {
+      link.image = { url: `/uploads/${req.file.filename}`, originalName: req.file.originalname };
+    }
+    try { await userModel.addLinks(id, [link]); }
+    catch (e) { console.error('add link', e); }
+  }
+  res.redirect(`/admin/teachers/${id}/edit?saved=1`);
+});
+
 
 router.get('/reports', async (_req, res) => {
 const classes = await classModel.getAllClasses();

--- a/routes/teacher.js
+++ b/routes/teacher.js
@@ -75,6 +75,19 @@ router.post('/profile', mediaUpload.single('photo'), async (req, res) => {
   res.redirect('/teacher/profile?saved=1');
 });
 
+router.post('/profile/links', mediaUpload.single('image'), async (req, res) => {
+  const { url } = req.body;
+  if (url) {
+    const link = { url };
+    if (req.file) {
+      link.image = { url: `/uploads/${req.file.filename}`, originalName: req.file.originalname };
+    }
+    try { await userModel.addLinks(req.session.user.id, [link]); }
+    catch (e) { console.error('add link', e); }
+  }
+  res.redirect('/teacher/profile?saved=1');
+});
+
 
 // Dashboard with weekly schedule and announcements
 router.get('/', async (req, res) => {

--- a/views/teacher_profile.ejs
+++ b/views/teacher_profile.ejs
@@ -20,8 +20,8 @@
         <div class="text-muted">No photo uploaded.</div>
       <% } %>
     </div>
-    <% if (role === 'admin') { %>
-      <form method="post" enctype="multipart/form-data" class="mb-3" style="max-width:400px;">
+    <% if (role === 'admin' || role === 'teacher') { %>
+      <form method="post" enctype="multipart/form-data" class="mb-3" style="max-width:400px;" action="<%= role === 'teacher' ? '/teacher/profile' : '/admin/teachers/' + teacher.id + '/edit' %>">
         <div class="mb-3">
           <label class="form-label">Upload Photo</label>
           <input type="file" name="photo" accept="image/*" class="form-control" />
@@ -29,6 +29,37 @@
         <button class="btn btn-primary">Save</button>
       </form>
     <% } %>
+
+    <% const links = (teacher.profile && teacher.profile.links) || []; %>
+    <% if (links.length) { %>
+      <h3>Links</h3>
+      <div class="d-flex flex-wrap mb-3">
+        <% links.forEach(l => { %>
+          <a href="<%= l.url %>" target="_blank" class="m-2" style="width:120px;height:120px;border-radius:8px;overflow:hidden;display:block;">
+            <% if (l.image && l.image.url) { %>
+              <img src="<%= l.image.url %>" alt="Link" style="width:100%;height:100%;object-fit:cover;">
+            <% } else { %>
+              <div class="border d-flex align-items-center justify-content-center h-100 w-100 text-muted">Link</div>
+            <% } %>
+          </a>
+        <% }) %>
+      </div>
+    <% } %>
+
+    <% if (role === 'admin' || role === 'teacher') { %>
+      <form method="post" enctype="multipart/form-data" class="mb-3" style="max-width:400px;" action="<%= role === 'teacher' ? '/teacher/profile/links' : '/admin/teachers/' + teacher.id + '/link' %>">
+        <div class="mb-3">
+          <label class="form-label">Link URL</label>
+          <input type="url" name="url" class="form-control" required />
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Image</label>
+          <input type="file" name="image" accept="image/*" class="form-control" />
+        </div>
+        <button class="btn btn-primary">Add Link</button>
+      </form>
+    <% } %>
+
     <p><strong>Username:</strong> @<%= teacher.username %></p>
     <p><strong>Email:</strong> <%= teacher.email %></p>
     <a href="javascript:history.back()" class="btn btn-link mt-3">Back</a>

--- a/views/view_class.ejs
+++ b/views/view_class.ejs
@@ -194,6 +194,22 @@
         <% } %>
       </section>
     </div>
+    <% if (studentView && teacher && teacher.profile && (teacher.profile.links || []).length) { %>
+      <section class="cardish mb-3" aria-labelledby="links-title">
+        <div class="section-title"><span class="dot"></span><span id="links-title">Links</span></div>
+        <div class="d-flex flex-wrap">
+          <% teacher.profile.links.forEach(l => { %>
+            <a href="<%= l.url %>" target="_blank" class="m-2" style="width:120px;height:120px;border-radius:8px;overflow:hidden;display:block;">
+              <% if (l.image && l.image.url) { %>
+                <img src="<%= l.image.url %>" alt="Link" style="width:100%;height:100%;object-fit:cover;">
+              <% } else { %>
+                <div class="border d-flex align-items-center justify-content-center h-100 w-100 text-muted">Link</div>
+              <% } %>
+            </a>
+          <% }) %>
+        </div>
+      </section>
+    <% } %>
 
    <!-- Lectures & Tests -->
     <div class="two-col">


### PR DESCRIPTION
## Summary
- allow teachers and admins to attach link cards with images to teacher profiles
- display teacher links to students on the class page and profile view
- persist teacher links in user profiles

## Testing
- `npm test` *(fails: jest not found)*
- `npx -y jest` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8fe0f508832b99fcba66cf5d86f2