### PR TITLE
feat: enhance events and marketing pages

### DIFF
--- a/models/eventModel.js
+++ b/models/eventModel.js
@@ -6,17 +6,22 @@ async function init() {
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     eventDate DATE NOT NULL,
-    description TEXT
+    description TEXT,
+    attachment VARCHAR(255)
   )`);
+  // ensure attachment column exists for older installs
+  await db
+    .query('ALTER TABLE mdtslms_events ADD COLUMN attachment VARCHAR(255) NULL')
+    .catch(() => {});
 }
 init().catch(console.error);
 
-async function createEvent({ name, eventDate, description }) {
+async function createEvent({ name, eventDate, description, attachment }) {
   const [result] = await db.query(
-    'INSERT INTO mdtslms_events (name, eventDate, description) VALUES (?,?,?)',
-    [name, eventDate, description]
+    'INSERT INTO mdtslms_events (name, eventDate, description, attachment) VALUES (?,?,?,?)',
+    [name, eventDate, description, attachment]
   );
-  return { id: result.insertId, name, eventDate, description };
+  return { id: result.insertId, name, eventDate, description, attachment };
 }
 
 async function getAllEvents() {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -125,7 +125,10 @@ router.post('/email-templates/ai', async (req, res) => {
       },
       body: JSON.stringify({
         model: 'gpt-3.5-turbo',
-        messages: [{ role: 'user', content: prompt }]
+        messages: [
+          { role: 'system', content: 'You generate personalized HTML email templates that use {{name}} placeholders.' },
+          { role: 'user', content: prompt }
+        ]
       })
     });
     const data = await response.json();
@@ -288,9 +291,10 @@ router.get('/create-event', (req, res) => {
 });
 
 // Handle event creation
-router.post('/create-event', async (req, res) => {
+router.post('/create-event', mediaUpload.single('attachment'), async (req, res) => {
   const { name, date, description } = req.body;
-  await eventModel.createEvent({ name, eventDate: date, description });
+  const attachment = req.file ? `/uploads/${req.file.filename}` : null;
+  await eventModel.createEvent({ name, eventDate: date, description, attachment });
   res.redirect('/admin');
 });
 

--- a/views/admin_email_templates.ejs
+++ b/views/admin_email_templates.ejs
@@ -33,6 +33,10 @@
         <textarea name="html" class="form-control" rows="10"><%= template.html %></textarea>
       </div>
       <div class="mb-3">
+        <label class="form-label">Preview</label>
+        <div id="htmlPreview" class="border rounded p-3"></div>
+      </div>
+      <div class="mb-3">
         <label class="form-label">AI Prompt</label>
         <textarea id="aiPrompt" class="form-control" rows="3"></textarea>
         <button type="button" id="aiBtn" class="btn btn-secondary mt-2">Generate with AI</button>
@@ -42,6 +46,12 @@
     <% } %>
   </div>
 <script>
+  const htmlBox = document.querySelector('textarea[name="html"]');
+  const preview = document.getElementById('htmlPreview');
+  function updatePreview(){ preview.innerHTML = htmlBox.value; }
+  htmlBox?.addEventListener('input', updatePreview);
+  document.addEventListener('DOMContentLoaded', updatePreview);
+
   document.getElementById('aiBtn')?.addEventListener('click', async () => {
     const prompt = document.getElementById('aiPrompt').value;
     if (!prompt.trim()) return;
@@ -52,7 +62,8 @@
     });
     const data = await res.json();
     if (data.html) {
-      document.querySelector('textarea[name="html"]').value = data.html;
+      htmlBox.value = data.html;
+      updatePreview();
     }
   });
 </script>

--- a/views/admin_marketing.ejs
+++ b/views/admin_marketing.ejs
@@ -41,10 +41,19 @@
         <div class="mb-3">
           <label class="form-label">Recipients</label>
           <div class="list-group">
-            <% students.forEach(function(s){ const full = s.name || (s.profile?.firstName + ' ' + s.profile?.lastName); %>
+            <% students.forEach(function(s){
+                 const full = s.name || (s.profile?.firstName + ' ' + s.profile?.lastName);
+                 const course = s.profile?.course || 'N/A';
+                 const aff = s.profile?.affiliateProgram || 'N/A';
+                 const signup = s.appliedAt ? new Date(s.appliedAt).toISOString().slice(0,10) : 'N/A';
+                 const enrolled = s.status === 'approved' ? 'Enrolled' : 'Not Enrolled';
+            %>
               <label class="list-group-item">
                 <input class="form-check-input me-1" type="checkbox" name="studentIds" value="<%= s.id %>">
-                <%= full %> (<%= s.email %>)
+                <div class="ms-2">
+                  <div><%= full %> (<%= s.email %>)</div>
+                  <small class="text-muted">Course: <%= course %> | Program: <%= aff %> | Signed up: <%= signup %> | <%= enrolled %></small>
+                </div>
               </label>
             <% }); %>
           </div>

--- a/views/create_event.ejs
+++ b/views/create_event.ejs
@@ -58,7 +58,7 @@
 
   <div class="container pb-4">
     <div class="cardish">
-      <form method="POST" action="/admin/create-event" novalidate>
+      <form method="POST" action="/admin/create-event" enctype="multipart/form-data" novalidate>
         <div class="mb-3">
           <label class="form-label">Event Name</label>
           <input type="text" name="name" class="form-control" required>
@@ -70,6 +70,10 @@
         <div class="mb-3">
           <label class="form-label">Description</label>
           <textarea name="description" class="form-control" rows="3" placeholder="Optional details"></textarea>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Attachment (PDF or Image)</label>
+          <input type="file" name="attachment" class="form-control" accept="image/*,application/pdf">
         </div>
         <div class="d-flex gap-2 mt-4">
           <button type="submit" class="btn btn-primary">Save Event</button>

--- a/views/events.ejs
+++ b/views/events.ejs
@@ -114,12 +114,14 @@
 
         <% if (!message) { %>
         <form method="POST" action="/events/rsvp" class="needs-validation" novalidate>
+          <!-- Attachment preview -->
+          <div id="attachmentPreview" class="mb-3 text-center"></div>
           <!-- Event -->
           <div class="mb-3">
             <label class="form-label req" for="eventId">Event</label>
             <select id="eventId" name="eventId" class="form-select" required>
               <% events.forEach(e => { %>
-                <option value="<%= e.id %>">
+                <option value="<%= e.id %>" data-attachment="<%= e.attachment || '' %>">
                   <%= e.name %> ( <%= new Date(e.eventDate).toISOString().slice(0,10) %> )
                 </option>
               <% }) %>
@@ -224,6 +226,26 @@
         btn?.setAttribute('disabled','disabled');
         spin?.classList.remove('d-none');
       });
+    })();
+
+    // Attachment preview
+    (function(){
+      const select = document.getElementById('eventId');
+      const preview = document.getElementById('attachmentPreview');
+      function update(){
+        const att = select?.options[select.selectedIndex]?.dataset.attachment;
+        if(att){
+          if(/\.(png|jpe?g|gif|webp|svg)$/i.test(att)){
+            preview.innerHTML = `<img src="${att}" class="img-fluid rounded mb-2" alt="Event attachment">`;
+          }else{
+            preview.innerHTML = `<a href="${att}" target="_blank" class="btn btn-outline-secondary mb-2">View attachment</a>`;
+          }
+        }else{
+          preview.innerHTML = '';
+        }
+      }
+      select?.addEventListener('change', update);
+      document.addEventListener('DOMContentLoaded', update);
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- allow admins to upload an image or PDF for events and show attachments on the RSVP form
- add live email preview and personalized AI template generation
- display richer student info on the marketing email page

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab98c2f534832ba4f57d092e5f661d