### PR TITLE
feat: allow admin branding customization

### DIFF
--- a/admin_user_guide.html
+++ b/admin_user_guide.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin User Guide</title>
+  <link rel="stylesheet" href="/css/theme.css">
+</head>
+<body>
+  <h1>Admin User Guide</h1>
+  <p>This guide explains how to manage the learning management system as an administrator.</p>
+  <h2>Branding</h2>
+  <p>Navigate to <strong>Branding</strong> in the navigation bar to update the site logo and the primary and secondary colors.</p>
+  <ol>
+    <li>Choose a new logo file and/or pick your desired colors.</li>
+    <li>Click <em>Save</em> to apply your changes across the application.</li>
+  </ol>
+  <h2>Other Tasks</h2>
+  <ul>
+    <li>Approve or deny student registrations.</li>
+    <li>Manage classes and events.</li>
+    <li>Create email templates and configure dropdown options.</li>
+  </ul>
+</body>
+</html>

--- a/app.js
+++ b/app.js
@@ -30,6 +30,9 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.get('/branding.json', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'branding.json'));
+});
 app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use(session({

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,5 +1,12 @@
 (function(){
   const root = document.documentElement;
+  fetch('/branding.json')
+    .then(r => r.json())
+    .then(b => {
+      if (b.primaryColor) root.style.setProperty('--primary-color', b.primaryColor);
+      if (b.secondaryColor) root.style.setProperty('--secondary-color', b.secondaryColor);
+    })
+    .catch(() => {});
   const stored = localStorage.getItem('theme');
   if (stored === 'dark' || stored === 'light') {
     root.setAttribute('data-theme', stored);

--- a/student_user_guide.html
+++ b/student_user_guide.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Student User Guide</title>
+  <link rel="stylesheet" href="/css/theme.css">
+</head>
+<body>
+  <h1>Student User Guide</h1>
+  <p>Follow these steps to make the most of the learning management system.</p>
+  <ul>
+    <li>Log in to view your enrolled classes and upcoming events.</li>
+    <li>Submit assignments and take tests assigned by your teachers.</li>
+    <li>Check announcements for important updates.</li>
+    <li>Review your grades and attendance on your dashboard.</li>
+  </ul>
+</body>
+</html>

--- a/teacher_user_guide.html
+++ b/teacher_user_guide.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Teacher User Guide</title>
+  <link rel="stylesheet" href="/css/theme.css">
+</head>
+<body>
+  <h1>Teacher User Guide</h1>
+  <p>This guide highlights the primary features available to teachers.</p>
+  <ul>
+    <li>View and manage your assigned classes from the dashboard.</li>
+    <li>Create and grade tests for your students.</li>
+    <li>Communicate with students through announcements and discussions.</li>
+    <li>Access reports to track student progress.</li>
+  </ul>
+</body>
+</html>

--- a/views/admin_branding.ejs
+++ b/views/admin_branding.ejs
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Branding Settings</title>
+  <link rel="icon" href="<%= branding.favicon %>" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/theme.css" />
+  <script src="/js/theme.js"></script>
+</head>
+<body>
+  <%- include('header', { user: user }) %>
+  <div class="container my-4">
+    <h1 class="h3 mb-3">Branding</h1>
+    <% if (saved) { %>
+      <div class="alert alert-success">Branding updated.</div>
+    <% } %>
+    <form action="/admin/branding" method="post" enctype="multipart/form-data" class="row g-3">
+      <div class="col-12">
+        <label for="primaryLogo" class="form-label">Site Logo</label>
+        <input type="file" class="form-control" id="primaryLogo" name="primaryLogo" />
+        <% if (branding.primaryLogo) { %>
+          <img src="<%= branding.primaryLogo %>" alt="Current logo" style="height:80px;margin-top:10px;" />
+        <% } %>
+      </div>
+      <div class="col-md-6">
+        <label for="primaryColor" class="form-label">Primary Color</label>
+        <input type="color" class="form-control form-control-color" id="primaryColor" name="primaryColor" value="<%= branding.primaryColor %>" />
+      </div>
+      <div class="col-md-6">
+        <label for="secondaryColor" class="form-label">Secondary Color</label>
+        <input type="color" class="form-control form-control-color" id="secondaryColor" name="secondaryColor" value="<%= branding.secondaryColor %>" />
+      </div>
+      <div class="col-12">
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </div>
+</body>
+</html>

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -1,4 +1,10 @@
 <link rel="stylesheet" href="/css/theme.css">
+<style>
+  :root{
+    --primary-color: <%= branding.primaryColor %>;
+    --secondary-color: <%= branding.secondaryColor %>;
+  }
+</style>
 <script src="/js/theme.js"></script>
 <header class="text-white p-3 mb-3 bg-primary">
   <div class="container d-flex justify-content-between align-items-center">
@@ -15,6 +21,7 @@
           <a class="nav-link-custom" href="/admin/reports">Reports</a>
                 <a class="nav-link-custom" href="/admin/email-templates">Email Templates</a>
                             <a class="nav-link-custom" href="/admin/dropdowns">Dropdowns</a>
+              <a class="nav-link-custom" href="/admin/branding">Branding</a>
         <% } %>
         <% if (user.role === 'teacher') { %>
           <a class="nav-link-custom" href="/teacher/reports">Reports</a>


### PR DESCRIPTION
## Summary
- enable administrators to update site logo and primary/secondary colors
- load branding colors on the client and expose branding JSON
- add HTML user guides for admins, teachers and students

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb7d25f5c832b9f226a5361dfd476