### PR TITLE
feat: enhance marketing emails with templates

### DIFF
--- a/data/marketingTemplates.json
+++ b/data/marketingTemplates.json
@@ -1,0 +1,22 @@
+{
+  "recruitment": {
+    "subject": "Join the MDTS Family Today!",
+    "html": "<div style=\"background:#f9f9f9;padding:30px;font-family:Arial,Helvetica,sans-serif;\">\n  <div style=\"max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.1);\">\n    <div style=\"background:linear-gradient(90deg,#1e3a8a,#2563eb);color:#fff;padding:20px;text-align:center;font-size:24px;font-weight:bold;\">MD Technical School</div>\n    {{imageTag}}\n    <div style=\"padding:20px;\">\n      <h2 style=\"color:#2563eb;margin-top:0;\">{{subject}}</h2>\n      <p style=\"font-size:16px;line-height:1.6;color:#444;\">{{message}}</p>\n    </div>\n    <div style=\"background:#f3f4f6;padding:10px;text-align:center;font-size:12px;color:#6b7280;\">© {{year}} MD Technical School</div>\n  </div>\n</div>"
+  },
+  "retention": {
+    "subject": "We Value Your Journey with MDTS",
+    "html": "<div style=\"background:#f9f9f9;padding:30px;font-family:Arial,Helvetica,sans-serif;\">\n  <div style=\"max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.1);\">\n    <div style=\"background:linear-gradient(90deg,#1e3a8a,#2563eb);color:#fff;padding:20px;text-align:center;font-size:24px;font-weight:bold;\">MD Technical School</div>\n    {{imageTag}}\n    <div style=\"padding:20px;\">\n      <h2 style=\"color:#2563eb;margin-top:0;\">{{subject}}</h2>\n      <p style=\"font-size:16px;line-height:1.6;color:#444;\">{{message}}</p>\n    </div>\n    <div style=\"background:#f3f4f6;padding:10px;text-align:center;font-size:12px;color:#6b7280;\">© {{year}} MD Technical School</div>\n  </div>\n</div>"
+  },
+  "approval": {
+    "subject": "Congratulations on Your Approval!",
+    "html": "<div style=\"background:#f9f9f9;padding:30px;font-family:Arial,Helvetica,sans-serif;\">\n  <div style=\"max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.1);\">\n    <div style=\"background:linear-gradient(90deg,#1e3a8a,#2563eb);color:#fff;padding:20px;text-align:center;font-size:24px;font-weight:bold;\">MD Technical School</div>\n    {{imageTag}}\n    <div style=\"padding:20px;\">\n      <h2 style=\"color:#2563eb;margin-top:0;\">{{subject}}</h2>\n      <p style=\"font-size:16px;line-height:1.6;color:#444;\">{{message}}</p>\n    </div>\n    <div style=\"background:#f3f4f6;padding:10px;text-align:center;font-size:12px;color:#6b7280;\">© {{year}} MD Technical School</div>\n  </div>\n</div>"
+  },
+  "events": {
+    "subject": "Exciting MDTS Events Ahead",
+    "html": "<div style=\"background:#f9f9f9;padding:30px;font-family:Arial,Helvetica,sans-serif;\">\n  <div style=\"max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.1);\">\n    <div style=\"background:linear-gradient(90deg,#1e3a8a,#2563eb);color:#fff;padding:20px;text-align:center;font-size:24px;font-weight:bold;\">MD Technical School</div>\n    {{imageTag}}\n    <div style=\"padding:20px;\">\n      <h2 style=\"color:#2563eb;margin-top:0;\">{{subject}}</h2>\n      <p style=\"font-size:16px;line-height:1.6;color:#444;\">{{message}}</p>\n    </div>\n    <div style=\"background:#f3f4f6;padding:10px;text-align:center;font-size:12px;color:#6b7280;\">© {{year}} MD Technical School</div>\n  </div>\n</div>"
+  },
+  "information": {
+    "subject": "Important Update from MDTS",
+    "html": "<div style=\"background:#f9f9f9;padding:30px;font-family:Arial,Helvetica,sans-serif;\">\n  <div style=\"max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.1);\">\n    <div style=\"background:linear-gradient(90deg,#1e3a8a,#2563eb);color:#fff;padding:20px;text-align:center;font-size:24px;font-weight:bold;\">MD Technical School</div>\n    {{imageTag}}\n    <div style=\"padding:20px;\">\n      <h2 style=\"color:#2563eb;margin-top:0;\">{{subject}}</h2>\n      <p style=\"font-size:16px;line-height:1.6;color:#444;\">{{message}}</p>\n    </div>\n    <div style=\"background:#f3f4f6;padding:10px;text-align:center;font-size:12px;color:#6b7280;\">© {{year}} MD Technical School</div>\n  </div>\n</div>"
+  }
+}

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -10,6 +10,10 @@ const preRegModel = require('../models/preRegModel');
 const eventModel = require('../models/eventModel');
 const rsvpModel = require('../models/rsvpModel');
 const emailTemplates = require('../utils/emailTemplates');
+const marketingTemplates = require('../data/marketingTemplates.json');
+const marketingSubjects = Object.fromEntries(
+  Object.entries(marketingTemplates).map(([k, v]) => [k, { subject: v.subject }])
+);
 const announcementModel = require('../models/announcementModel');
 const testModel = require('../models/testModel');
 const dripCampaign = require('../utils/dripCampaign');
@@ -500,12 +504,22 @@ const marketingPrefaces = {
 // Marketing email form
 router.get('/marketing', async (req, res) => {
   const students = await userModel.getByRole('student');
-  res.render('admin_marketing', { students, user: req.session.user, sent: req.query.sent, error: null });
+  const preregs = await preRegModel.getAll();
+  const rsvps = await rsvpModel.getAllRSVPs();
+  res.render('admin_marketing', {
+    students,
+    preregs,
+    rsvps,
+    templates: marketingSubjects,
+    user: req.session.user,
+    sent: req.query.sent,
+    error: null
+  });
 });
 
 // Preview marketing email with OpenAI
 router.post('/marketing/preview', async (req, res) => {
-  const { type, message } = req.body;
+  const { type, message, subject, imageUrl } = req.body;
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) return res.status(500).json({ error: 'Missing OpenAI API key' });
   if (!marketingTypes.includes(type)) return res.status(400).json({ error: 'Invalid type' });
@@ -525,7 +539,14 @@ router.post('/marketing/preview', async (req, res) => {
     });
     const data = await response.json();
     const generated = data.choices?.[0]?.message?.content?.trim() || '';
-    res.json({ message: generated });
+    const tpl = marketingTemplates[type];
+    const subj = subject && subject.trim() ? subject.trim() : tpl.subject;
+    const html = tpl.html
+      .replace(/{{imageTag}}/g, imageUrl ? `<img src="${imageUrl}" alt="" style="width:100%;height:auto;display:block;">` : '')
+      .replace(/{{subject}}/g, subj)
+      .replace(/{{message}}/g, generated)
+      .replace(/{{year}}/g, new Date().getFullYear());
+    res.json({ html });
   } catch (e) {
     console.error('OpenAI preview error', e);
     res.status(500).json({ error: 'Failed to generate preview' });
@@ -535,13 +556,24 @@ router.post('/marketing/preview', async (req, res) => {
 // Send marketing email
 router.post('/marketing', async (req, res) => {
   const students = await userModel.getByRole('student');
-  const { studentIds, type, subject, imageUrl, message } = req.body;
-  const ids = Array.isArray(studentIds) ? studentIds : [studentIds].filter(Boolean);
+  const preregs = await preRegModel.getAll();
+  const rsvps = await rsvpModel.getAllRSVPs();
+  const { recipients, type, subject, imageUrl, message } = req.body;
+  const ids = Array.isArray(recipients) ? recipients : [recipients].filter(Boolean);
   if (!ids.length || !marketingTypes.includes(type)) {
-    return res.status(400).render('admin_marketing', { students, user: req.session.user, sent: null, error: 'Invalid form submission.' });
+    return res.status(400).render('admin_marketing', {
+      students,
+      preregs,
+      rsvps,
+      templates: marketingSubjects,
+      user: req.session.user,
+      sent: null,
+      error: 'Invalid form submission.'
+    });
   }
   try {
-    const subj = (subject && subject.trim()) || `MDTS ${type.charAt(0).toUpperCase() + type.slice(1)} Update`;
+    const tpl = marketingTemplates[type];
+    const subj = (subject && subject.trim()) || tpl.subject;
     const preface = marketingPrefaces[type] || '';
     let bodyText = `${preface}\n\n${message || ''}`;
     const apiKey = process.env.OPENAI_API_KEY;
@@ -565,20 +597,26 @@ router.post('/marketing', async (req, res) => {
       }
     }
 
-    const html = `
-      <div style="font-family:Arial,sans-serif;text-align:center;background:#f0f8ff;padding:20px;">
-        ${imageUrl ? `<img src="${imageUrl}" alt="" style="max-width:100%;height:auto;margin-bottom:15px;border-radius:8px;">` : ''}
-        <h2 style="color:#ff4081;">${subj}</h2>
-        <p style="font-size:1.1rem;">${bodyText}</p>
-      </div>
-    `;
+    const html = tpl.html
+      .replace(/{{imageTag}}/g, imageUrl ? `<img src="${imageUrl}" alt="" style="width:100%;height:auto;display:block;">` : '')
+      .replace(/{{subject}}/g, subj)
+      .replace(/{{message}}/g, bodyText)
+      .replace(/{{year}}/g, new Date().getFullYear());
 
     for (const id of ids) {
-      const student = await userModel.findById(Number(id));
-      if (!student || !student.email) continue;
+      const [kind, actualId] = String(id).split('-');
+      let recipient;
+      if (kind === 'student') {
+        recipient = await userModel.findById(Number(actualId));
+      } else if (kind === 'pre') {
+        recipient = preregs.find(p => p.id === Number(actualId));
+      } else if (kind === 'rsvp') {
+        recipient = rsvps.find(r => r.id === Number(actualId));
+      }
+      if (!recipient || !recipient.email) continue;
       await transporter.sendMail({
         from: 'no-reply@mdts-apps.com',
-        to: student.email,
+        to: recipient.email,
         subject: subj,
         html,
         text: bodyText
@@ -588,7 +626,15 @@ router.post('/marketing', async (req, res) => {
     res.redirect('/admin/marketing?sent=1');
   } catch (e) {
     console.error('Error sending marketing email', e);
-    res.status(500).render('admin_marketing', { students, user: req.session.user, sent: null, error: 'Failed to send email.' });
+    res.status(500).render('admin_marketing', {
+      students,
+      preregs,
+      rsvps,
+      templates: marketingSubjects,
+      user: req.session.user,
+      sent: null,
+      error: 'Failed to send email.'
+    });
   }
 });
 

--- a/views/admin_marketing.ejs
+++ b/views/admin_marketing.ejs
@@ -40,23 +40,23 @@
       <form id="marketingForm" method="post" action="/admin/marketing">
         <div class="mb-3">
           <label class="form-label">Recipients</label>
-          <div class="list-group">
+          <select name="recipients" class="form-select" multiple size="10">
             <% students.forEach(function(s){
                  const full = s.name || (s.profile?.firstName + ' ' + s.profile?.lastName);
                  const course = s.profile?.course || 'N/A';
                  const aff = s.profile?.affiliateProgram || 'N/A';
                  const signup = s.appliedAt ? new Date(s.appliedAt).toISOString().slice(0,10) : 'N/A';
-                 const enrolled = s.status === 'approved' ? 'Enrolled' : 'Not Enrolled';
+                 const status = s.status === 'approved' ? 'Enrolled' : (s.status === 'declined' ? 'Denied' : 'Pending');
             %>
-              <label class="list-group-item">
-                <input class="form-check-input me-1" type="checkbox" name="studentIds" value="<%= s.id %>">
-                <div class="ms-2">
-                  <div><%= full %> (<%= s.email %>)</div>
-                  <small class="text-muted">Course: <%= course %> | Program: <%= aff %> | Signed up: <%= signup %> | <%= enrolled %></small>
-                </div>
-              </label>
+              <option value="student-<%= s.id %>" title="Course: <%= course %> | Program: <%= aff %> | Signed up: <%= signup %>"><%= status %> - <%= full %> (<%= s.email %>)</option>
             <% }); %>
-          </div>
+            <% preregs.forEach(function(p){ %>
+              <option value="pre-<%= p.id %>" title="Course: <%= p.course %>">Pre-registered - <%= p.name %> (<%= p.email %>)</option>
+            <% }); %>
+            <% rsvps.forEach(function(r){ %>
+              <option value="rsvp-<%= r.id %>" title="Event: <%= r.eventName %>">RSVP - <%= r.fullName %> (<%= r.email %>)</option>
+            <% }); %>
+          </select>
         </div>
         <div class="mb-3">
           <label class="form-label">Email Type</label>
@@ -80,8 +80,7 @@
           <label class="form-label">Message</label>
           <textarea name="message" class="form-control" rows="6"></textarea>
         </div>
-        <div id="preview" class="alert alert-secondary" style="display:none;"></div>
-        <button type="button" id="previewBtn" class="btn btn-secondary me-2">Preview</button>
+        <div id="preview" class="mt-3" style="display:none;"></div>
         <button type="submit" class="btn btn-primary">Send Email</button>
       </form>
     </div>
@@ -94,34 +93,55 @@
       events: 'Upcoming opportunities await you at MDTS.',
       information: 'Here is an important update from MDTS.'
     };
+    const templates = <%- JSON.stringify(templates) %>;
     const typeSelect = document.querySelector('select[name="type"]');
     const messageBox = document.querySelector('textarea[name="message"]');
-    const previewBtn = document.getElementById('previewBtn');
+    const subjectInput = document.querySelector('input[name="subject"]');
+    const imageInput = document.querySelector('input[name="imageUrl"]');
     const previewDiv = document.getElementById('preview');
     let touched = false;
-    messageBox.addEventListener('input', () => { touched = true; });
+    messageBox.addEventListener('input', () => { touched = true; fetchPreview(); });
+    imageInput.addEventListener('input', fetchPreview);
+
     function updatePreface() {
       if (touched && messageBox.value.trim()) return;
       const pre = prefaces[typeSelect.value] || '';
       messageBox.value = pre;
     }
-    typeSelect.addEventListener('change', updatePreface);
-    document.addEventListener('DOMContentLoaded', updatePreface);
 
-    previewBtn.addEventListener('click', async () => {
+    function updateSubject() {
+      subjectInput.value = templates[typeSelect.value]?.subject || '';
+    }
+
+    async function fetchPreview() {
       const body = new URLSearchParams();
       body.append('type', typeSelect.value);
       body.append('message', messageBox.value);
+      body.append('subject', subjectInput.value);
+      body.append('imageUrl', imageInput.value);
       const res = await fetch('/admin/marketing/preview', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: body.toString()
       });
       const data = await res.json();
-      if (data.message) {
+      if (data.html) {
         previewDiv.style.display = 'block';
-        previewDiv.textContent = data.message;
+        previewDiv.innerHTML = data.html;
       }
+    }
+
+    typeSelect.addEventListener('change', () => {
+      touched = false;
+      updatePreface();
+      updateSubject();
+      fetchPreview();
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      updatePreface();
+      updateSubject();
+      fetchPreview();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- replace marketing recipients with status-prefixed dropdown
- style marketing email templates and auto-fill subjects
- auto-preview selected template in marketing page

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac54a58188832bbb4d9ec2dcf4905b