### PR TITLE
feat: support marketing image upload

### DIFF
--- a/views/admin_marketing.ejs
+++ b/views/admin_marketing.ejs
@@ -37,7 +37,7 @@
       <div class="alert alert-danger"><%= error %></div>
     <% } %>
     <div class="cardish mt-3">
-      <form id="marketingForm" method="post" action="/admin/marketing">
+      <form id="marketingForm" method="post" action="/admin/marketing" enctype="multipart/form-data">
         <div class="mb-3">
           <label class="form-label">Recipients</label>
           <select name="recipients" class="form-select" multiple size="10">
@@ -73,8 +73,8 @@
           <input type="text" name="subject" class="form-control">
         </div>
         <div class="mb-3">
-          <label class="form-label">Image URL</label>
-          <input type="url" name="imageUrl" class="form-control">
+          <label class="form-label">Image</label>
+          <input type="file" name="image" class="form-control" accept="image/*">
         </div>
         <div class="mb-3">
           <label class="form-label">Message</label>
@@ -97,11 +97,11 @@
     const typeSelect = document.querySelector('select[name="type"]');
     const messageBox = document.querySelector('textarea[name="message"]');
     const subjectInput = document.querySelector('input[name="subject"]');
-    const imageInput = document.querySelector('input[name="imageUrl"]');
+    const imageInput = document.querySelector('input[name="image"]');
     const previewDiv = document.getElementById('preview');
     let touched = false;
     messageBox.addEventListener('input', () => { touched = true; fetchPreview(); });
-    imageInput.addEventListener('input', fetchPreview);
+    imageInput.addEventListener('change', fetchPreview);
 
     function updatePreface() {
       if (touched && messageBox.value.trim()) return;
@@ -114,15 +114,14 @@
     }
 
     async function fetchPreview() {
-      const body = new URLSearchParams();
+      const body = new FormData();
       body.append('type', typeSelect.value);
       body.append('message', messageBox.value);
       body.append('subject', subjectInput.value);
-      body.append('imageUrl', imageInput.value);
+      if (imageInput.files[0]) body.append('image', imageInput.files[0]);
       const res = await fetch('/admin/marketing/preview', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: body.toString()
+        body
       });
       const data = await res.json();
       if (data.html) {

--- a/views/view_class.ejs
+++ b/views/view_class.ejs
@@ -240,16 +240,17 @@
             <% }) %>
           </ul>
         <% } %>
-          <% if (typeof studentView === 'undefined' || !studentView) { %>
-                 <form method="POST" action="/admin/classes/<%= klass.id %>/lectures" enctype="multipart/form-data" class="mt-3 d-flex gap-2 flex-wrap">
-            <input type="text" name="title" class="form-control" placeholder="Title" style="max-width:200px">
-            <input type="url" name="url" class="form-control" placeholder="URL">
-            <input type="file" name="ppt" class="form-control" accept=".ppt,.pptx">
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" name="isPowerPoint" id="ppt-<%= klass.id %>">
-              <label class="form-check-label" for="ppt-<%= klass.id %>">PowerPoint</label>
+        <% if (typeof studentView === 'undefined' || !studentView) { %>
+          <form method="POST" action="/admin/classes/<%= klass.id %>/lectures" class="mt-3 row g-2 align-items-end">
+            <div class="col-md-4">
+              <input type="text" name="title" class="form-control" placeholder="Title">
             </div>
-            <button class="btn btn-sm btn-primary" type="submit">Add</button>
+            <div class="col-md-6">
+              <input type="url" name="url" class="form-control" placeholder="URL">
+            </div>
+            <div class="col-md-2">
+              <button class="btn btn-primary w-100" type="submit">Add</button>
+            </div>
           </form>
         <% } %>
       </section>
@@ -269,10 +270,16 @@
           </ul>
         <% } %>
         <% if (typeof studentView === 'undefined' || !studentView) { %>
-          <form method="POST" action="/admin/classes/<%= klass.id %>/simulations" class="mt-3 d-flex gap-2 flex-wrap">
-            <input type="text" name="title" class="form-control" placeholder="Title" style="max-width:200px">
-            <input type="url" name="url" class="form-control" placeholder="URL">
-            <button class="btn btn-sm btn-primary" type="submit">Add</button>
+          <form method="POST" action="/admin/classes/<%= klass.id %>/simulations" class="mt-3 row g-2 align-items-end">
+            <div class="col-md-4">
+              <input type="text" name="title" class="form-control" placeholder="Title">
+            </div>
+            <div class="col-md-6">
+              <input type="url" name="url" class="form-control" placeholder="URL">
+            </div>
+            <div class="col-md-2">
+              <button class="btn btn-primary w-100" type="submit">Add</button>
+            </div>
           </form>
         <% } %>
       </section>
@@ -292,11 +299,19 @@
           </ul>
         <% } %>
         <% if (typeof studentView === 'undefined' || !studentView) { %>
-          <form method="POST" action="/admin/classes/<%= klass.id %>/assignments" class="mt-3 d-flex gap-2 flex-wrap">
-            <input type="text" name="title" class="form-control" placeholder="Title" style="max-width:200px">
-            <input type="url" name="url" class="form-control" placeholder="URL">
-              <input type="date" name="date" class="form-control" style="max-width:200px">
-            <button class="btn btn-sm btn-primary" type="submit">Add</button>
+          <form method="POST" action="/admin/classes/<%= klass.id %>/assignments" class="mt-3 row g-2 align-items-end">
+            <div class="col-md-4">
+              <input type="text" name="title" class="form-control" placeholder="Title">
+            </div>
+            <div class="col-md-4">
+              <input type="url" name="url" class="form-control" placeholder="URL">
+            </div>
+            <div class="col-md-2">
+              <input type="date" name="date" class="form-control">
+            </div>
+            <div class="col-md-2">
+              <button class="btn btn-primary w-100" type="submit">Add</button>
+            </div>
           </form>
         <% } %>
       </section>


### PR DESCRIPTION
## Summary
- allow marketing emails to include uploaded images instead of URL links
- simplify lecture additions by removing PowerPoint upload option and refreshing form layout
- tidy class admin page layout for lectures, simulations, and assignments

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ac5b95a664832ba19b2ff73229310d