### PR TITLE
Attach marketing media and allow class renaming

### DIFF
--- a/models/classModel.js
+++ b/models/classModel.js
@@ -52,6 +52,11 @@ async function duplicateClass(id) {
   return findClassById(result.insertId);
 }
 
+async function renameClass(id, name) {
+  await db.query('UPDATE mdtslms_classes SET name=? WHERE id=?', [name, id]);
+  return findClassById(id);
+}
+
 async function addTest(classId, test) {
   const klass = await findClassById(classId);
   if (!klass) return null;
@@ -192,7 +197,8 @@ module.exports = {
   upsertAssignmentGrade,
   upsertLabStatus,
   duplicateClass,
-  updateChecklist
+  updateChecklist,
+  renameClass
 };
 
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -561,6 +561,9 @@ router.post('/marketing', mediaUpload.single('image'), async (req, res) => {
   const rsvps = await rsvpModel.getAllRSVPs();
   const { recipients, type, subject, message } = req.body;
   const imageUrl = req.file ? `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}` : null;
+  const attachments = req.file
+    ? [{ filename: req.file.originalname, path: req.file.path }]
+    : [];
   const ids = Array.isArray(recipients) ? recipients : [recipients].filter(Boolean);
   if (!ids.length || !marketingTypes.includes(type)) {
     return res.status(400).render('admin_marketing', {
@@ -621,7 +624,8 @@ router.post('/marketing', mediaUpload.single('image'), async (req, res) => {
         to: recipient.email,
         subject: subj,
         html,
-        text: bodyText
+        text: bodyText,
+        attachments
       });
     }
 
@@ -979,6 +983,15 @@ router.post('/classes/:id/duplicate', async (req, res) => {
   const copy = await classModel.duplicateClass(id);
   if (!copy) return res.status(404).send('Not found');
   res.redirect(`/admin/classes/${copy.id}`);
+});
+
+router.post('/classes/:id/rename', async (req, res) => {
+  const id = Number(req.params.id);
+  const { name } = req.body;
+  if (name && name.trim()) {
+    await classModel.renameClass(id, name.trim());
+  }
+  res.redirect(`/admin/classes/${id}`);
 });
 
 router.post('/users/:id/deactivate', async (req, res) => {

--- a/routes/teacher.js
+++ b/routes/teacher.js
@@ -189,6 +189,15 @@ router.get('/classes/:id', async (req, res) => {
   res.render('teacher_view_class', { klass, students, today, attendanceToday, discussions });
 });
 
+router.post('/classes/:id/rename', async (req, res) => {
+  const id = Number(req.params.id);
+  const { name } = req.body;
+  if (name && name.trim()) {
+    await classModel.renameClass(id, name.trim());
+  }
+  res.redirect(`/teacher/classes/${id}`);
+});
+
 // add discussion message
 router.post('/classes/:id/discussion', async (req, res) => {
   const classId = Number(req.params.id);

--- a/views/teacher_view_class.ejs
+++ b/views/teacher_view_class.ejs
@@ -133,6 +133,11 @@
             <% if (klass.weeks) { %> &nbsp;•&nbsp; Duration: <strong><%= klass.weeks %> weeks</strong><% } %>
           </p>
         </div>
+        <div class="d-flex gap-2">
+          <button class="btn btn-outline-primary" type="button" id="renameBtn">
+            <i class="bi bi-pencil"></i> Rename
+          </button>
+        </div>
       </div>
     </div>
   </header>
@@ -528,6 +533,24 @@
         URL.revokeObjectURL(url);
       });
     })();
+  </script>
+
+  <script>
+    document.getElementById('renameBtn')?.addEventListener('click', () => {
+      const newName = prompt('Enter new class name:', <%- JSON.stringify(klass.name) %>);
+      if (newName && newName.trim()) {
+        const form = document.createElement('form');
+        form.method = 'post';
+        form.action = '/teacher/classes/<%= klass.id %>/rename';
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'name';
+        input.value = newName.trim();
+        form.appendChild(input);
+        document.body.appendChild(form);
+        form.submit();
+      }
+    });
   </script>
 </body>
 </html>

--- a/views/view_class.ejs
+++ b/views/view_class.ejs
@@ -145,6 +145,9 @@
             <i class="bi bi-files"></i> Duplicate
           </button>
         </form>
+        <button class="btn btn-outline-primary" type="button" id="renameBtn">
+          <i class="bi bi-pencil"></i> Rename
+        </button>
       </div>
       <% } %>
     </div>
@@ -448,7 +451,7 @@
    
     <% } %>
   </main>
-    <% if (klass.startDate) { %>
+  <% if (klass.startDate) { %>
   <script>
     (function(){
       const el=document.getElementById('startCountdown');
@@ -463,5 +466,22 @@
     })();
   </script>
   <% } %>
+  <script>
+    document.getElementById('renameBtn')?.addEventListener('click', () => {
+      const newName = prompt('Enter new class name:', <%- JSON.stringify(klass.name) %>);
+      if (newName && newName.trim()) {
+        const form = document.createElement('form');
+        form.method = 'post';
+        form.action = '/admin/classes/<%= klass.id %>/rename';
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'name';
+        input.value = newName.trim();
+        form.appendChild(input);
+        document.body.appendChild(form);
+        form.submit();
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Attach uploaded images as email attachments when sending marketing emails
- Add rename endpoints and buttons for admins and teachers to update duplicated class names

## Testing
- `npm test` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68ac5eb43f5c832bbcdb88912dce58d4